### PR TITLE
Squash latest Lineage-OS commits till Oct. 18, 2017, 16:00 KST

### DIFF
--- a/fs/sdcardfs/dentry.c
+++ b/fs/sdcardfs/dentry.c
@@ -192,7 +192,13 @@ static void sdcardfs_canonical_path(const struct path *path,
 	sdcardfs_get_real_lower(path->dentry, actual_path);
 }
 
+static int sdcardfs_d_delete(const struct dentry * dentry)
+{
+	return dentry->d_inode && !S_ISDIR(dentry->d_inode->i_mode);
+}
+
 const struct dentry_operations sdcardfs_ci_dops = {
+	.d_delete	= sdcardfs_d_delete,
 	.d_revalidate	= sdcardfs_d_revalidate,
 	.d_release	= sdcardfs_d_release,
 	.d_hash	= sdcardfs_hash_ci,

--- a/fs/sdcardfs/dentry.c
+++ b/fs/sdcardfs/dentry.c
@@ -63,7 +63,14 @@ static int sdcardfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
 	lower_cur_parent_dentry = dget_parent(lower_dentry);
 
 	if ((lower_dentry->d_flags & DCACHE_OP_REVALIDATE)) {
+		struct path ptmp;
+		if (nd) {
+			pathcpy(&ptmp, &nd->path);
+			pathcpy(&nd->path, &lower_path);
+		}
 		err = lower_dentry->d_op->d_revalidate(lower_dentry, nd);
+		if (nd)
+			pathcpy(&nd->path, &ptmp);
 		if (err == 0) {
 			d_drop(dentry);
 			goto out;

--- a/fs/sdcardfs/inode.c
+++ b/fs/sdcardfs/inode.c
@@ -194,7 +194,6 @@ static int sdcardfs_unlink(struct inode *dir, struct dentry *dentry)
 	sdcardfs_get_lower_path(dentry, &lower_path);
 	lower_dentry = lower_path.dentry;
 	lower_mnt = lower_path.mnt;
-	dget(lower_dentry);
 	lower_dir_dentry = lock_parent(lower_dentry);
 
 	err = mnt_want_write(lower_path.mnt);
@@ -223,7 +222,6 @@ out:
 	mnt_drop_write(lower_path.mnt);
 out_unlock:
 	unlock_dir(lower_dir_dentry);
-	dput(lower_dentry);
 	sdcardfs_put_lower_path(dentry, &lower_path);
 	REVERT_CRED(saved_cred);
 out_eacces:

--- a/net/wireless/nl80211.c
+++ b/net/wireless/nl80211.c
@@ -6601,6 +6601,9 @@ static int nl80211_set_rekey_data(struct sk_buff *skb, struct genl_info *info)
 	if (err)
 		return err;
 
+	if (!tb[NL80211_REKEY_DATA_REPLAY_CTR] || !tb[NL80211_REKEY_DATA_KEK] ||
+	    !tb[NL80211_REKEY_DATA_KCK])
+		return -EINVAL;
 	if (nla_len(tb[NL80211_REKEY_DATA_REPLAY_CTR]) != NL80211_REPLAY_CTR_LEN)
 		return -ERANGE;
 	if (nla_len(tb[NL80211_REKEY_DATA_KEK]) != NL80211_KEK_LEN)


### PR DESCRIPTION
* sdcardfs: minor fixes
The removal of dget/dput is only a cleanup.

Change-Id: Ib18c3406414b506de476a3a4aecf029196923037
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>

* sdcardfs: fix space leak
Don't keep looked up dentries around because there's no notification
when the lowerfs unlinks an inode, to collect the upper dentry cache so
the lower inode reference can be released and the storage space
released.

This effectively disables the dcache lookups but it should still be much
faster than fuse sdcardfs.

The alternative is to add a notification mechanism to keep two separate
dcache layers in sync which isn't trivial, or stop ever touching the
lower fs and remove that path.replace from VolumeInfo.java.

Change-Id: I211bd676834126f6f65b3d09ebe951d0375d7985
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>

* nl80211: check for the required netlink attributes presence
commit e785fa0a164aa11001cba931367c7f94ffaff888 upstream.

nl80211_set_rekey_data() does not check if the required attributes
NL80211_REKEY_DATA_{REPLAY_CTR,KEK,KCK} are present when processing
NL80211_CMD_SET_REKEY_OFFLOAD request. This request can be issued by
users with CAP_NET_ADMIN privilege and may result in NULL dereference
and a system crash. Add a check for the required attributes presence.
This patch is based on the patch by bo Zhang.

This fixes CVE-2017-12153.

Change-Id: I630bdee6706f5010557af74a879f0b1b4579d596
References: https://bugzilla.redhat.com/show_bug.cgi?id=1491046
Fixes: e5497d7 ("cfg80211/nl80211: support GTK rekey offload")
Reported-by: bo Zhang <zhangbo5891001@gmail.com>
Signed-off-by: Vladis Dronov <vdronov@redhat.com>
Signed-off-by: Johannes Berg <johannes.berg@intel.com>
Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>

Signed-off-by: sunilpaulmathew <sunil.kde@gmail.com>